### PR TITLE
Bugfix problem with duplicate runner and hide kobalt functionality if project contains no Build.kt file

### DIFF
--- a/src/com/beust/kobalt/intellij/BuildUtils.kt
+++ b/src/com/beust/kobalt/intellij/BuildUtils.kt
@@ -1,0 +1,11 @@
+package com.beust.kobalt.intellij
+
+import com.intellij.openapi.project.Project
+
+/**
+ * @author Dmitry Zhuravlev
+ *         Date:  25.04.2016
+ */
+object  BuildUtils {
+    fun buildFileExist(project: Project?) = project?.baseDir?.findFileByRelativePath(Constants.BUILD_FILE)!=null
+}

--- a/src/com/beust/kobalt/intellij/SyncBuildFileAction.kt
+++ b/src/com/beust/kobalt/intellij/SyncBuildFileAction.kt
@@ -1,7 +1,7 @@
 package com.beust.kobalt.intellij
 
 import com.beust.kobalt.intellij.toolWindow.KobaltToolWindowComponent
-import com.intellij.openapi.actionSystem.AnAction
+import com.beust.kobalt.intellij.toolWindow.actions.KobaltAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
@@ -15,10 +15,13 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
  * @author Cedric Beust <cedric@beust.com>
  * @since 10 23, 2015
  */
-class SyncBuildFileAction : AnAction("Sync build file") {
+class SyncBuildFileAction : KobaltAction("Sync build file") {
     companion object {
         val LOG = Logger.getInstance(SyncBuildFileAction::class.java)
     }
+
+    override fun isAvailable(e: AnActionEvent) = BuildUtils.buildFileExist(e.project)
+
 
     override fun actionPerformed(event: AnActionEvent) {
         FileDocumentManager.getInstance().saveAllDocuments()

--- a/src/com/beust/kobalt/intellij/execution/KobaltTaskConfigurationType.kt
+++ b/src/com/beust/kobalt/intellij/execution/KobaltTaskConfigurationType.kt
@@ -1,11 +1,11 @@
 package com.beust.kobalt.intellij.execution
 
 import com.intellij.execution.RunManager
+import com.intellij.execution.RunnerRegistry
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
 import com.intellij.execution.configurations.ConfigurationTypeUtil
 import com.intellij.execution.executors.DefaultRunExecutor
-import com.intellij.execution.impl.DefaultJavaProgramRunner
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.project.Project
@@ -34,7 +34,7 @@ class KobaltTaskConfigurationType : ConfigurationType {
 
         fun runConfiguration(project: Project, tasks:List<String>) {
             val type = ConfigurationTypeUtil.findConfigurationType<KobaltTaskConfigurationType>(KobaltTaskConfigurationType::class.java)
-            val runner = DefaultJavaProgramRunner.getInstance();
+            val runner = RunnerRegistry.getInstance().findRunnerById(KobaltTaskRunner.RUNNER_ID);
             val executor = DefaultRunExecutor.getRunExecutorInstance()
             val settings = RunManager.getInstance(project).createRunConfiguration("Kobalt $tasks", type.configurationFactory)
             val configuration = settings.configuration as KobaltTaskRunConfiguration

--- a/src/com/beust/kobalt/intellij/execution/KobaltTaskRunConfiguration.kt
+++ b/src/com/beust/kobalt/intellij/execution/KobaltTaskRunConfiguration.kt
@@ -18,7 +18,11 @@ import com.intellij.openapi.roots.ProjectRootManager
  */
 class KobaltTaskRunConfiguration(project: Project, var tasks: List<String> = emptyList()) : LocatableConfigurationBase(project,
         findConfigurationType<KobaltTaskConfigurationType>(KobaltTaskConfigurationType::class.java).configurationFactory,
-        "TODO NAME") {
+        CONFIGURATION_NAME) {
+
+    companion object{
+        const val CONFIGURATION_NAME = "KOBALT_TASK_RUN_CONFIGURATION"
+    }
 
     val kobaltComponent = project.getComponent(KobaltProjectComponent::class.java)
 

--- a/src/com/beust/kobalt/intellij/execution/KobaltTaskRunner.kt
+++ b/src/com/beust/kobalt/intellij/execution/KobaltTaskRunner.kt
@@ -1,7 +1,6 @@
 package com.beust.kobalt.intellij.execution
 
 import com.intellij.execution.configurations.RunProfile
-import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.impl.DefaultJavaProgramRunner
 
 /**
@@ -10,9 +9,11 @@ import com.intellij.execution.impl.DefaultJavaProgramRunner
  */
 class KobaltTaskRunner : DefaultJavaProgramRunner() {
     companion object{
-        const val EXECUTOR_NAME ="Run task"
+        const val RUNNER_ID ="RUN_KOBALT_TASK_RUNNER"
     }
 
+    override fun getRunnerId() = RUNNER_ID
+
     override fun canRun(executorId: String, profile: RunProfile) =
-            DefaultRunExecutor.EXECUTOR_ID == executorId && profile.name == EXECUTOR_NAME
+            RUNNER_ID == executorId && profile.name == KobaltTaskRunConfiguration.CONFIGURATION_NAME
 }

--- a/src/com/beust/kobalt/intellij/toolWindow/KobaltProjectsStructure.kt
+++ b/src/com/beust/kobalt/intellij/toolWindow/KobaltProjectsStructure.kt
@@ -1,7 +1,7 @@
 package com.beust.kobalt.intellij.toolWindow
 
 import com.beust.kobalt.intellij.ProjectData
-import com.beust.kobalt.intellij.toolWindow.BaseNode.ProjectNode
+import com.beust.kobalt.intellij.toolWindow.BaseNode.ModuleNode
 import com.beust.kobalt.intellij.toolWindow.BaseNode.RootNode
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
@@ -39,7 +39,7 @@ class KobaltProjectsStructure(val project: Project, tree: SimpleTree) : SimpleTr
             rootNode.cleanUpCache()
             rootNode.removeAllChildren()
         }
-        projectData.map { ProjectNode(it.name, rootNode) }.forEach { node ->
+        projectData.map { ModuleNode(it.name, rootNode) }.forEach { node ->
             rootNode.add(node)
 
         }

--- a/src/com/beust/kobalt/intellij/toolWindow/KobaltProjectsTreeNodes.kt
+++ b/src/com/beust/kobalt/intellij/toolWindow/KobaltProjectsTreeNodes.kt
@@ -1,8 +1,10 @@
 package com.beust.kobalt.intellij.toolWindow
 
 import com.beust.kobalt.intellij.toolWindow.actions.KobaltActionUtil
+import com.intellij.ide.projectView.PresentationData
 import com.intellij.ui.treeStructure.CachingSimpleNode
 import com.intellij.ui.treeStructure.SimpleTree
+import icons.ExternalSystemIcons
 import java.awt.event.InputEvent
 
 /**
@@ -27,19 +29,24 @@ sealed class BaseNode(var displayName: String, var parent: BaseNode?) : CachingS
         }
     }
 
-    class TaskNode(displayName: String, parent: BaseNode, override val actionId: String? = "kobalt.RunTask") : BaseNode(displayName, parent)
+    class TaskNode(displayName: String, parent: BaseNode, override val actionId: String? = "kobalt.RunTask") : BaseNode(displayName, parent){
+        override fun update(presentation: PresentationData?) {
+            super.update(presentation)
+            presentation?.setIcon(ExternalSystemIcons.Task)
+        }
+    }
 
     class RootNode : BaseNode("", null) {
         override val actionId = null
 
-        val projectNodes = mutableListOf<ProjectNode>()
+        val projectNodes = mutableListOf<ModuleNode>()
 
-        fun add(node: ProjectNode) {
+        fun add(node: ModuleNode) {
             node.parent = this
             projectNodes.add(node)
         }
 
-        fun remove(node: ProjectNode) {
+        fun remove(node: ModuleNode) {
             node.parent = this
             projectNodes.remove(node)
         }
@@ -49,7 +56,12 @@ sealed class BaseNode(var displayName: String, var parent: BaseNode?) : CachingS
         override fun doBuildChildren() = projectNodes
     }
 
-    class ProjectNode(displayName: String, parent: BaseNode) : BaseNode(displayName, parent) {
+    class ModuleNode(displayName: String, parent: BaseNode) : BaseNode(displayName, parent) {
+
+        override fun update(presentation: PresentationData?) {
+            super.update(presentation)
+            presentation?.setIcon(ExternalSystemIcons.TaskGroup)
+        }
 
         override val actionId = null
 

--- a/src/com/beust/kobalt/intellij/toolWindow/KobaltToolWindowComponent.kt
+++ b/src/com/beust/kobalt/intellij/toolWindow/KobaltToolWindowComponent.kt
@@ -9,8 +9,10 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.*
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupManager
 import com.intellij.openapi.util.InvalidDataException
 import com.intellij.openapi.util.WriteExternalException
+import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.treeStructure.SimpleTree
 import com.intellij.util.DisposeAwareRunnable
 import org.jdom.Element
@@ -59,6 +61,18 @@ class KobaltToolWindowComponent(project: Project) : AbstractProjectComponent(pro
             }
 
         }, myProject), ModalityState.defaultModalityState())
+    }
+
+    override fun projectOpened() {
+        StartupManager.getInstance(myProject).runWhenProjectIsInitialized {
+            hideToolWindowIfNeeded()
+        }
+    }
+
+    private fun hideToolWindowIfNeeded() {
+        if(!BuildUtils.buildFileExist(myProject)) {
+            ToolWindowManager.getInstance(myProject)?.getToolWindow("Kobalt Build")?.setAvailable(false, null)
+        }
     }
 
     fun update(projectData: List<ProjectData>) {

--- a/src/com/beust/kobalt/intellij/toolWindow/KobaltToolWindowComponent.kt
+++ b/src/com/beust/kobalt/intellij/toolWindow/KobaltToolWindowComponent.kt
@@ -1,5 +1,6 @@
 package com.beust.kobalt.intellij.toolWindow
 
+import com.beust.kobalt.intellij.BuildUtils
 import com.beust.kobalt.intellij.DependenciesProcessor
 import com.beust.kobalt.intellij.KobaltProjectComponent
 import com.beust.kobalt.intellij.ProjectData
@@ -46,9 +47,10 @@ class KobaltToolWindowComponent(project: Project) : AbstractProjectComponent(pro
     override fun initComponent() {
         initTree()
         ApplicationManager.getApplication().invokeLater(DisposeAwareRunnable.create({
-            val dependencyProcessor = DependenciesProcessor()
-            projectStructure = KobaltProjectsStructure(myProject, tree)
             myProject.getComponent(KobaltProjectComponent::class.java)?.let { kobaltComponent ->
+                if(!BuildUtils.buildFileExist(myProject)) return@let
+                val dependencyProcessor = DependenciesProcessor()
+                projectStructure = KobaltProjectsStructure(myProject, tree)
                 dependencyProcessor.run(kobaltComponent, myProject) { projectsData ->
                     projectStructure.update(projectsData)
                     isInitialized = true


### PR DESCRIPTION
- Fix problem with duplicate runner
- Hide plugin functionality if project contains no Build.kt file
- Added icons for module and tasks nodes
